### PR TITLE
Changed brick recipe to use clayballs

### DIFF
--- a/src/main/resources/data/campfire_overhaul/recipes/bricks_from_campfire.json
+++ b/src/main/resources/data/campfire_overhaul/recipes/bricks_from_campfire.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:campfire_cooking",
   "ingredient": {
-    "item": "minecraft:clay"
+    "item": "minecraft:clay_ball"
   },
   "result": "minecraft:brick",
   "cookingtime": 600


### PR DESCRIPTION
Hello!
First, thank you for the mod, It fits perfect with vanilla and gives a really nice realistic touch.

I changed the brick recipe to use clay balls instead of clay blocks as the furnace recipe counterpart. I thought using blocks is unintentional.

~ Zahkriiven
